### PR TITLE
Validator: update function names, add a couple functions

### DIFF
--- a/data/LORA/convert.py
+++ b/data/LORA/convert.py
@@ -5,11 +5,11 @@ import xarray as xr
 
 from ilamb3_data import (
     add_time_bounds_monthly,
-    download_file,
-    fix_lat,
-    fix_lon,
-    fix_time,
+    download_from_html,
     gen_utc_timestamp,
+    set_lat_attrs,
+    set_lon_attrs,
+    set_time_attrs,
 )
 
 # Download source
@@ -23,7 +23,7 @@ for remote_source in remote_sources:
     local_source.mkdir(parents=True, exist_ok=True)
     source = local_source / Path(remote_source).name
     if not source.is_file():
-        download_file(remote_source, str(source))
+        download_from_html(remote_source, str(source))
     local_sources.append(source)
 download_stamp = gen_utc_timestamp(local_sources[0].stat().st_mtime)
 generate_stamp = gen_utc_timestamp()
@@ -35,14 +35,14 @@ out["mrro_sd"].attrs["long_name"] = "runoff_flux standard_deviation"
 out["mrro_sd"].attrs["stadard_name"] = "runoff_flux standard_deviation"
 
 # Fix up the dimensions
-out["time"] = fix_time(out)
-out["lat"] = fix_lat(out)
-out["lon"] = fix_lon(out)
+out = set_time_attrs(out)
+out = set_lat_attrs(out)
+out = set_lon_attrs(out)
 out = out.sortby(["time", "lat", "lon"])
 out = out.cf.add_bounds(["lat", "lon"])
 out = add_time_bounds_monthly(out)
-time_range = f"{out["time"].min().dt.year:d}{out["time"].min().dt.month:02d}"
-time_range += f"-{out["time"].max().dt.year:d}{out["time"].max().dt.month:02d}"
+time_range = f"{out['time'].min().dt.year:d}{out['time'].min().dt.month:02d}"
+time_range += f"-{out['time'].max().dt.year:d}{out['time'].max().dt.month:02d}"
 
 # Populate attributes
 attrs = {

--- a/data/WECANN/convert.py
+++ b/data/WECANN/convert.py
@@ -6,12 +6,12 @@ import xarray as xr
 
 from ilamb3_data import (
     add_time_bounds_monthly,
-    download_file,
-    fix_lat,
-    fix_lon,
-    fix_time,
+    download_from_html,
     gen_utc_timestamp,
     get_cmip6_variable_info,
+    set_lat_attrs,
+    set_lon_attrs,
+    set_time_attrs,
 )
 
 RENAME = {"GPP": "gpp", "H": "hfss", "LE": "hfls"}
@@ -23,7 +23,7 @@ local_source = Path("_raw")
 local_source.mkdir(parents=True, exist_ok=True)
 local_source = local_source / Path(remote_source).name
 if not local_source.is_file():
-    download_file(remote_source, str(local_source))
+    download_from_html(remote_source, str(local_source))
 download_stamp = gen_utc_timestamp(local_source.stat().st_mtime)
 generate_stamp = gen_utc_timestamp()
 
@@ -58,9 +58,9 @@ for var, da in data.items():
 out = xr.Dataset(data_vars=data, coords=coords)
 
 # Fix up the dimensions
-out["time"] = fix_time(out)
-out["lat"] = fix_lat(out)
-out["lon"] = fix_lon(out)
+out = set_time_attrs(out)
+out = set_lon_attrs(out)
+out = set_lat_attrs(out)
 out = out.sortby(["time", "lat", "lon"])
 out = out.cf.add_bounds(["lat", "lon"])
 out = add_time_bounds_monthly(out)

--- a/data/WOA/convert.py
+++ b/data/WOA/convert.py
@@ -5,7 +5,7 @@ import numpy as np
 import xarray as xr
 
 from ilamb3_data import (
-    download_file,
+    download_from_html,
     gen_utc_timestamp,
 )
 
@@ -56,7 +56,7 @@ for vname, remote_sources in remote_source_dict.items():
         local_source_dict[vname].append(source)
         source.parent.mkdir(parents=True, exist_ok=True)
         if not source.is_file():
-            download_file(remote_source, str(source))
+            download_from_html(remote_source, str(source))
         download_stamp = gen_utc_timestamp(source.stat().st_mtime)
 generate_stamp = gen_utc_timestamp()
 


### PR DESCRIPTION
This PR reflects some changes to `init.py` as well as necessary changes to the WOA, LORA, and WECANN scripts to reflect new function names.

## Changes to `init.py`

### Renamed existing functions
- [x] Renamed functions like `fix_lat` to `set_lat_attrs` to be more specific about the functionality
- [x] Renamed `download_file` to `download_from_html` so we can make various downloader functions
    - Recommend adding `download_from_earthdata` in the future as well

### Edited existing functions
- [x] Edited functions like `set_lat_attrs` to return an xr.Dataset instead of xr.DataArray (I feel like modifying the ds directly is easier to use and reflects the format of other similar functions)
- [x] Added a line in `download_from_html` to handle when content-length is 0 (i.e., previously, a file was still downloadable but the 0 length needed by the progress bar broke the download)

### Added new functions
- [x] Added `download_from_zenodo` to download files via a zenodo API record
- [x] Added a `get_filename` function (this will likely change in the future)
- [x] Added a `set_var_attrs` function to ensure users properly assign attributes to their variable