### PR TITLE
Update RAPID

### DIFF
--- a/data/RAPID/convert.py
+++ b/data/RAPID/convert.py
@@ -1,133 +1,141 @@
-from pathlib import Path
+import sys
 from datetime import datetime
+from pathlib import Path
 
-import cftime as cf
+import numpy as np
 import xarray as xr
-import os
 
 from ilamb3_data import (
-    add_time_bounds2, 
-    fix_time,
-    fix_lat,
-    gen_utc_timestamp,
-    set_ods_global_attributes,
+    create_output_filename,
     gen_trackingid,
-    set_ods_var_attrs,
-    set_ods_coords,
-    )
+    gen_utc_timestamp,
+    get_cmip6_variable_info,
+    set_depth_attrs,
+    set_lat_attrs,
+    set_ods_global_attrs,
+    set_time_attrs,
+    set_var_attrs,
+    standardize_dim_order,
+)
 
-today = datetime.now().strftime("%Y%m%d")
-
-# Download source, cannot be downloaded automatically
+# Follow link to download source; it cannot be downloaded automatically
+# Select "MOC transports in NetCDF format" for download
 remote_source = "https://rapid.ac.uk/data/data-download"
 local_source = Path("_raw")
 local_source.mkdir(parents=True, exist_ok=True)
-local_source = local_source / "moc_transports.nc"
-download_stamp = gen_utc_timestamp(local_source.stat().st_mtime)
-generate_stamp = gen_utc_timestamp()
+source = local_source / "moc_transports.nc"
+if not source.is_file():
+    print(
+        f"NetCDF has not been downloaded. Navigate here ({remote_source}) to request download of 'MOC transports in NetCDF format'"
+    )
+    sys.exit(1)
 
-generate_trackingid = gen_trackingid()
+# Set timestamps and tracking id
+download_stamp = gen_utc_timestamp(source.stat().st_mtime)
+creation_stamp = gen_utc_timestamp()
+today_stamp = datetime.now().strftime("%Y%m%d")
+tracking_id = gen_trackingid()
 
 # Load the dataset for adjustments
-ds = xr.open_dataset(local_source).load()
+ds = xr.open_dataset(source)
 
-# Adding the 'basin' coordinate
-basin = xr.DataArray(["atlantic_ocean"], dims=["basin"], name="basin")
+# Create latitude dimension
+lat_da = xr.DataArray(
+    [26.5], dims=["lat"], name="lat", attrs={"units": "degrees_north"}
+)
 
-# Adding the 'latitude' coordinate (scalar for 26°N)
-latitude = xr.DataArray([26.0], dims=["lat"], name="lat", attrs={"units": "degrees_north"})
-
-# Adding a scalar olevel to indicate the vertically integrated nature of the data
-olevel = xr.DataArray([0.0], dims=["olevel"], name="olevel", attrs={"units": "m", "long_name": "integrated depth"})
+# Create depth dimension
+depth_da = xr.DataArray(
+    [0],
+    dims=["depth"],
+    name="depth",
+)
 
 # Assigning the coordinates to the dataset
-ds = ds.assign_coords({'basin':basin, 'lat':latitude, 'olevel':olevel,"YYYYMM": ds["time"].dt.year * 100 + ds["time"].dt.month})
-ds = ds.groupby("YYYYMM").mean().rename({"YYYYMM": "time"})
-ds["time"] = [
-    cf.DatetimeGregorian(int(ym / 100), (ym - int(ym / 100) * 100), 15)
-    for ym in ds["time"]
-]
-ds = add_time_bounds2(ds)
-ds = ds.assign_coords({"time_bnds": ds["time_bnds"]})
-ds["time"] = fix_time(ds)
-ds['time'].attrs['bounds'] = 'time_bnds'
+ds = ds.assign_coords({"lat": lat_da, "depth": depth_da})
+ds = set_time_attrs(ds, bounds_frequency="12H")
 
-ds = ds.drop_vars([v for v in ds.data_vars if v != "moc_mar_hc10"]).rename_vars(
-    {"moc_mar_hc10": "msftmz"}
+# Get monthly means instead of 12-hourly
+ds_decoded = xr.decode_cf(ds)
+monthly_ds = ds_decoded.resample(time="MS").mean(keep_attrs=True)
+
+# Select data var
+ds = monthly_ds.drop_vars(
+    [v for v in monthly_ds.data_vars if v != "moc_mar_hc10"]
+).rename_vars({"moc_mar_hc10": "msftmz"})
+
+# Assign coordinates to data var
+ds["msftmz"] = ds["msftmz"].expand_dims({"depth": ds["depth"], "lat": ds["lat"]})
+
+# Set var attrs
+var_info = get_cmip6_variable_info("msftmz")
+ds = set_var_attrs(
+    ds,
+    var="msftmz",
+    cmip6_units=var_info["variable_units"],
+    cmip6_standard_name=var_info["cf_standard_name"],
+    cmip6_long_name=var_info["variable_long_name"],
+    target_dtype=np.float32,
+    convert=False,
 )
 
+# Clean up attrs
+ds = set_time_attrs(ds, bounds_frequency="M")
+ds = set_lat_attrs(ds)
+ds = set_depth_attrs(
+    ds,
+    bounds=np.array([[0, 2000]]),
+    units="meters",
+    positive="down",
+    long_name="depth of sea water",
+)
 
-ds["msftmz"].attrs = {
-    "standard_name": "ocean_meridional_overturning_mass_streamfunction",
-    "long_name": "Ocean Meridional Overturning Mass Streamfunction",
-    "comment":"Overturning mass streamfunction arising from all advective mass transport processes, resolved and parameterized.",
-    "units": "Sv",
-}
-ds["msftmz"] = ds[
-        "msftmz"
-    ].assign_coords(basin="atlantic_ocean", lat=26.0, olevel=0)
-ds['lat'] = fix_lat(ds)
-ds = set_ods_coords(ds)
+ds = standardize_dim_order(ds)
 
-# Fix up the dimensions
-time_range = f"{ds["time"].min().dt.year:d}{ds["time"].min().dt.month:02d}"
-time_range += f"-{ds["time"].max().dt.year:d}{ds["time"].max().dt.month:02d}"
-
-# Populate attributes
-ds.attrs = {
-    "activity_id": "obs4MIPs",
-    "contact": "Ben Moat (ben.moat@noc.ac.uk)",
-    "Conventions": "CF-1.12 ODS-2.5",
-    "creation_date": generate_stamp,
-    "comment":"Not yet obs4MIPs compliant: 'version' attribute is temporary; source_id not in obs4MIPs yet; Units Sv for variable msftmz must be convertible to canonical units kg s-1" ,
-    "dataset_contributor": "Nathan Collier",
-    "data_specs_version": "2.5",
-    "doi": "10.5285/223b34a32dc5c945e0637086abc0f274",
-    "frequency": "mon",
-    "grid": "N/A",
-    "grid_label": "NA",
-    "has_auxdata":"False",
-    "history": f"""
+# Set global attributes and export
+out_ds = set_ods_global_attrs(
+    ds,
+    activity_id="obs4MIPs",
+    comment="Not yet obs4MIPs compliant: 'version' attribute is temporary; source_id not in obs4MIPs yet",
+    contact="Ben Moat (ben.moat@noc.ac.uk)",
+    conventions="CF-1.12 ODS-2.5",
+    creation_date=creation_stamp,
+    dataset_contributor="Morgan Steckler",
+    data_specs_version="2.5",
+    doi="10.5285/33826d6e-801c-b0a7-e063-7086abc0b9db",
+    external_variables="N/A",
+    frequency="mon",
+    grid="global mean data",
+    grid_label="gm",
+    has_auxdata="False",
+    history=f"""
 {download_stamp}: downloaded {remote_source};
-{generate_stamp}: converted to obs4MIP format""",
-    "institution": "National Oceanography Centre,UK",
-    "institution_id": "NOC",
-    "license": "Freely available",
-    "nominal_resolution": "N/A",
-    "processing_code_location": "https://github.com/rubisco-sfa/ilamb3-data/blob/main/data/RAPID/convert.py",
-    "product": "derived",
-    "realm": "ocean",
-    "region": "north_atlantic_ocean",
-    "references": "Moat B.I.; Smeed D.A.; Rayner D.; Johns W.E.; Smith, R.; Volkov, D.; Elipot S.; Petit T.; Kajtar J.; Baringer M. O.; and Collins, J. (2024). Atlantic meridional overturning circulation observed by the RAPID-MOCHA-WBTS (RAPID-Meridional Overturning Circulation and Heatflux Array-Western Boundary Time Series) array at 26N from 2004 to 2023 (v2023.1), British Oceanographic Data Centre - Natural Environment Research Council, UK. doi: 10.5285/223b34a3-2dc5-c945-e063-7086abc0f274",
-    "source": "The RAPID-Meridional Overturning Circulation and Heatflux Array-Western Boundary Time Series at 26N that started in April 2004.",
-    "source_id": "RAPID",
-    "source_data_retrieval_date": download_stamp,
-    "source_data_url": remote_source,
-    "source_type": "insitu",
-    "source_label":"RAPID",
-    "source_version_number": "2023.1",
-    "title": "RAPID MOC timeseries",
-    "variable_id": "msftmz",
-    "variant_label": "REF",
-    "variant_info":"CMORized product prepared by ILAMB and CMIP IPO",
-    "version":today,
-    "tracking_id": generate_trackingid,
-}
-
-#ds = set_ods_var_attrs(ds, "msftmz")
-#ds = set_ods_global_attributes(ds, **ds.attrs)
-
-out_path = (
-    "/home/users/dhegedus/CMIPplacement/beta/{activity_id}/{institution_id}/{source_id}/{frequency}/{variable_id}/{grid_label}/"
-    + today
-    + "/{variable_id}_{frequency}_{source_id}_{variant_label}_{grid_label}_{time_mark}.nc"
-).format(**ds.attrs, time_mark=time_range)
-
-os.makedirs(os.path.dirname(out_path), exist_ok=True)
-
-ds.to_netcdf(out_path,
-    encoding={'time_bnds':{'_FillValue':None, "dtype": "float64", "units": "days since 2004-04-01 00:00:00"},
-                'time':{"dtype": "float64", "units": "days since 2004-04-01 00:00:00",
-                        '_FillValue':None, "calendar": "gregorian"},
-                'lat': {'zlib': False, '_FillValue': None}},
+{today_stamp}: aggregated 12-hour timeseries to monthly;
+{creation_stamp}: converted to obs4MIPs format""",
+    institution="National Oceanography Centre, UK",
+    institution_id="NOC",
+    license="Data in this file produced by ILAMB is licensed under a Creative Commons Attribution- 4.0 International (CC BY 4.0) License (https://creativecommons.org/licenses/).",
+    nominal_resolution="site",
+    processing_code_location="https://github.com/rubisco-sfa/ilamb3-data/blob/main/data/RAPID/convert.py",
+    product="derived",
+    realm="ocean",
+    references="Moat, B.I., Smeed, D.A., Rayner, D., Johns, W.E., Smith, R., Volkov, D., Elipot, S., Petit, T., Kajtar, J., Baringer, M.O., Collins, J. (2025). Atlantic meridional overturning circulation observed by the RAPID-MOCHA-WBTS (RAPID-Meridional Overturning Circulation and Heatflux Array-Western Boundary Time Series) array at 26N from 2004 to 2023 (v2023.1a), British Oceanographic Data Centre - Natural Environment Research Council, UK. https://doi.org/10.5285/33826d6e-801c-b0a7-e063-7086abc0b9db",
+    region="atlantic_ocean",
+    source="Atlantic meridional overturning circulation observed by the RAPID-Meridional Overturning Circulation and Heatflux Array-Western Boundary",
+    source_id="RAPID-2023-1a",
+    source_data_retrieval_date=download_stamp,
+    source_data_url="https://rapid.ac.uk/data/data-download",
+    source_label="RAPID",
+    source_type="insitu",
+    source_version_number="2023.1a",
+    title="RAPID AMOC observations (v2023.1a)",
+    tracking_id=tracking_id,
+    variable_id="msftmz",
+    variant_label="REF",
+    variant_info="CMORized product prepared by ILAMB and CMIP IPO",
+    version=f"v{today_stamp}",
 )
+
+# Prep for export
+out_path = create_output_filename(out_ds.attrs)
+out_ds.to_netcdf(out_path, format="NETCDF4")

--- a/ilamb3_data/__init__.py
+++ b/ilamb3_data/__init__.py
@@ -414,6 +414,8 @@ def set_time_attrs(
     3) Drop & regenerate time_bnds (with matching encoding)
     """
 
+    created_time = False
+
     if "time" not in ds.coords:
         if sdate is None or edate is None:
             raise ValueError(
@@ -839,6 +841,10 @@ def gen_utc_timestamp(time: float | None = None) -> str:
 
 def gen_trackingid() -> str:
     return "hdl:21.14102/" + str(uuid.uuid4())
+
+
+def standardize_dim_order(ds, order=("time", "depth", "lat", "lon", "bnds")):
+    return ds.transpose(*order, missing_dims="ignore")
 
 
 def set_cf_global_attributes(


### PR DESCRIPTION
Note: will fail checks, not added to climatemodeling
Updated: 19 Aug 2025
Closes issue: #29 

## msftmz ncdump
<img width="940" height="407" alt="Screenshot 2025-08-19 at 2 46 11 PM" src="https://github.com/user-attachments/assets/f61ebc41-0887-485c-9202-3c6579561a44" />

```
netcdf obs4MIPs_NOC_RAPID-2023-1a_mon_msftmz_gm_v20250819 {
dimensions:
        time = 227 ;
        depth = 1 ;
        lat = 1 ;
        bnds = 2 ;
variables:
        float msftmz(time, depth, lat) ;
                msftmz:_FillValue = 1.e+20f ;
                msftmz:long_name = "Ocean Meridional Overturning Mass Streamfunction" ;
                msftmz:units = "Sv" ;
                msftmz:standard_name = "ocean_meridional_overturning_mass_streamfunction" ;
        double lat(lat) ;
                lat:axis = "Y" ;
                lat:units = "degrees_north" ;
                lat:standard_name = "latitude" ;
                lat:long_name = "Latitude" ;
        double time(time) ;
                time:axis = "T" ;
                time:standard_name = "time" ;
                time:long_name = "time" ;
                time:bounds = "time_bnds" ;
                time:units = "days since 2004-04-01 00:00:00" ;
                time:calendar = "standard" ;
        double time_bnds(time, bnds) ;
        float depth(depth) ;
                depth:units = "meters" ;
                depth:positive = "down" ;
                depth:axis = "Z" ;
                depth:standard_name = "depth" ;
                depth:long_name = "depth of sea water" ;
                depth:bounds = "depth_bnds" ;
        float depth_bnds(depth, bnds) ;

// global attributes:
                :activity_id = "obs4MIPs" ;
                :aux_variable_id = "N/A" ;
                :comment = "Not yet obs4MIPs compliant: \'version\' attribute is temporary; source_id not in obs4MIPs yet" ;
                :contact = "Ben Moat (ben.moat@noc.ac.uk)" ;
                :Conventions = "CF-1.12 ODS-2.5" ;
                :creation_date = "2025-08-19T18:44:30Z" ;
                :dataset_contributor = "Morgan Steckler" ;
                :data_specs_version = "2.5" ;
                :doi = "10.5285/33826d6e-801c-b0a7-e063-7086abc0b9db" ;
                :frequency = "mon" ;
                :grid = "global mean data" ;
                :grid_label = "gm" ;
                :has_auxdata = "False" ;
                :history = "\n2025-08-12T16:08:07Z: downloaded https://rapid.ac.uk/data/data-download;\n20250819: aggregated 12-hour timeseries to monthly;\n2025-08-19T18:44:30Z: converted to obs4MIPs format" ;
                :institution = "National Oceanography Centre, UK" ;
                :institution_id = "NOC" ;
                :license = "Data in this file produced by ILAMB is licensed under a Creative Commons Attribution- 4.0 International (CC BY 4.0) License (https://creativecommons.org/licenses/)." ;
                :nominal_resolution = "site" ;
                :processing_code_location = "https://github.com/rubisco-sfa/ilamb3-data/blob/main/data/RAPID/convert.py" ;
                :product = "derived" ;
                :realm = "ocean" ;
                :references = "Moat, B.I., Smeed, D.A., Rayner, D., Johns, W.E., Smith, R., Volkov, D., Elipot, S., Petit, T., Kajtar, J., Baringer, M.O., Collins, J. (2025). Atlantic meridional overturning circulation observed by the RAPID-MOCHA-WBTS (RAPID-Meridional Overturning Circulation and Heatflux Array-Western Boundary Time Series) array at 26N from 2004 to 2023 (v2023.1a), British Oceanographic Data Centre - Natural Environment Research Council, UK. https://doi.org/10.5285/33826d6e-801c-b0a7-e063-7086abc0b9db" ;
                :region = "atlantic_ocean" ;
                :source = "Atlantic meridional overturning circulation observed by the RAPID-Meridional Overturning Circulation and Heatflux Array-Western Boundary" ;
                :source_data_retrieval_date = "2025-08-12T16:08:07Z" ;
                :source_data_url = "https://rapid.ac.uk/data/data-download" ;
                :source_id = "RAPID-2023-1a" ;
                :source_label = "RAPID" ;
                :source_type = "insitu" ;
                :source_version_number = "2023.1a" ;
                :title = "RAPID AMOC observations (v2023.1a)" ;
                :tracking_id = "hdl:21.14102/4f7fc0eb-a75e-4aef-995a-2a0d13b4ec20" ;
                :variable_id = "msftmz" ;
                :variant_info = "CMORized product prepared by ILAMB and CMIP IPO" ;
                :variant_label = "REF" ;
                :version = "v20250819" ;
}
```