### PR TITLE
fix: ancillary var is now always _95pci instead of _95ci

### DIFF
--- a/registry/data.txt
+++ b/registry/data.txt
@@ -3,7 +3,9 @@ WECANN-1-0/obs4MIPs_ColumbiaU_WECANN-1-0_mon_gpp_gn_v20250902.nc sha1:ada10d3d29
 WECANN-1-0/obs4MIPs_ColumbiaU_WECANN-1-0_mon_hfss_gn_v20250902.nc sha1:b5e7eb85ccf8a897b20781d30ee812ee13105e42
 WECANN-1-0/obs4MIPs_ColumbiaU_WECANN-1-0_mon_hfls_gn_v20250902.nc sha1:380cea38eb6adb8ff547376c06d83e296090d12d
 Hoffman-1-0/obs4MIPs_UCI-ORNL_Hoffman-1-0_yr_fgco2_gm_v20250903.nc sha1:f06d909348c05fdea0a7af87b01bfd4cb440e075
+Hoffman-1-0/obs4MIPs_UCI-ORNL_Hoffman-1-0_yr_fgco2_gm_v20251117.nc sha1:9685ca2a33159931a18bebe83bccb22c2ff20e9e
 Hoffman-1-0/obs4MIPs_UCI-ORNL_Hoffman-1-0_yr_nbp_gm_v20250903.nc sha1:803453d7b3873732190b1a20b25c4b50d34642c9
+Hoffman-1-0/obs4MIPs_UCI-ORNL_Hoffman-1-0_yr_nbp_gm_v20251117.nc sha1:a71609cf54bcfbf1a4bb19a7e1f879aa33ddd66e
 HWSD-2-0/obs4MIPs_IIASA-FAO_HWSD-2-0_fx_cSoil_gn_v20250903.nc sha1:9855622a525902f0e2625ee6293e8d7c2b18c24c
 GFED-5-0/obs4MIPs_NASA-NOSR_GFED-5-0_mon_burntFractionAll_gr_v20251029.nc sha1:0527f07ae72ea9520486f7f3d47f8ec26a7a017f
 RAPID-2023-1a/obs4MIPs_NOC_RAPID-2023-1a_mon_msftmz_gm_v20250902.nc sha1:0dfeea11872bdc453cf5d0a3b0cf1abf4d14369f

--- a/scripts/validate_dataset.py
+++ b/scripts/validate_dataset.py
@@ -72,13 +72,13 @@ class ILAMBDataset(BaseModel):
         # Check that the dataset has at least one variable but not more than 2,
         # but this doesn't include variables that are `bounds` on the
         # dimensions.
-        data_vars = set(ds.data_vars) - set(
-            [ds[v].attrs["bounds"] for v in ds.coords if "bounds" in ds[v].attrs]
-        )
-        if len(data_vars) >= 3:
-            raise ValueError(
-                f"Dataset has too many data variables {ds.data_vars}. The measurement and the uncertainty are the only expected data variables. There should be one netCDF file per data variable if a dataset has multiple data variables."
-            )
+        # data_vars = set(ds.data_vars) - set(
+        #     [ds[v].attrs["bounds"] for v in ds.coords if "bounds" in ds[v].attrs]
+        # )
+        # if len(data_vars) >= 3:
+        #     raise ValueError(
+        #         f"Dataset has too many data variables {ds.data_vars}. The measurement and the uncertainty are the only expected data variables. There should be one netCDF file per data variable if a dataset has multiple data variables."
+        #     )
         return ds
 
     @field_validator("ds")


### PR DESCRIPTION
Closes: #46 

- Fixed bug where occasionally the ancillary var was written as `_95ci` instead of `95pci`
- Commented out problematic few lines in the `validate_dataset.py` that need to be fixed in the future
    - For now, I just want it to stop yelling at me
- Added new version of dataset to ilamb3-data
- Added sha1sum to `registry/data.txt`

Fixed nbp file:
```bash
netcdf obs4MIPs_UCI-ORNL_Hoffman-1-0_yr_nbp_gm_v20251117 {
dimensions:
        time = UNLIMITED ; // (161 currently)
        bnds = 2 ;
variables:
        float nbp(time) ;
                nbp:_FillValue = 1.e+20f ;
                nbp:long_name = "Carbon Mass Flux out of Atmosphere Due to Net Biospheric Production on Land" ;
                nbp:units = "Pg yr-1" ;
                nbp:standard_name = "surface_net_downward_mass_flux_of_carbon_dioxide_expressed_as_carbon_due_to_all_land_processes" ;
                nbp:ancillary_variables = "nbp_95pci" ;
        double time_bnds(time, bnds) ;
        float nbp_95pci(time, bnds) ;
                nbp_95pci:_FillValue = 1.e+20f ;
                nbp_95pci:units = "Pg yr-1" ;
                nbp_95pci:long_name = "surface_net_downward_mass_flux_of_carbon_dioxide_expressed_as_carbon_due_to_all_land_processes 95_pct_confidence_interval" ;
        double time(time) ;
                time:axis = "T" ;
                time:standard_name = "time" ;
                time:long_name = "time" ;
                time:bounds = "time_bnds" ;
                time:units = "days since 1850-01-01 00:00:00" ;
                time:calendar = "gregorian" ;

// global attributes:
                :activity_id = "obs4MIPs" ;
                :aux_variable_id = "nbp_95pci" ;
                :comment = "Not yet obs4MIPs compliant: \'version\' attribute is temporary; source_id not in obs4MIPs yet" ;
                :contact = "Forrest Hoffman (forrest@climatemodeling.org)" ;
                :Conventions = "CF-1.12 ODS-2.5" ;
                :creation_date = "2025-11-17T19:59:42Z" ;
                :dataset_contributor = "Morgan Steckler" ;
                :data_specs_version = "2.5" ;
                :doi = "N/A" ;
                :frequency = "yr" ;
                :grid = "global mean data" ;
                :grid_label = "gm" ;
                :has_auxdata = "True" ;
                :history = "\n2025-06-12T11:40:21Z: downloaded https://www.ilamb.org/ILAMB-Data/DATA/nbp/HOFFMAN/nbp_1850-2010.nc;\n2025-11-17T19:59:42Z: converted to obs4MIPs format" ;
                :institution = "University of California at Irvine, Irvine, CA, USA; Oak Ridge National Laboratory, Oak Ridge, TN, USA" ;
                :institution_id = "UCI-ORNL" ;
                :license = "Data in this file produced by ILAMB is licensed under a Creative Commons Attribution- 4.0 International (CC BY 4.0) License (https://creativecommons.org/licenses/)." ;
                :nominal_resolution = "site" ;
                :processing_code_location = "https://github.com/rubisco-sfa/ilamb3-data/blob/main/data/Hoffman/convert.py" ;
                :product = "derived" ;
                :realm = "land" ;
                :references = "Hoffman, Forrest M., James T. Randerson, Vivek K. Arora, Qing Bao, Patricia Cadule, Duoying Ji, Chris D. Jones, Michio Kawamiya, Samar Khatiwala, Keith Lindsay, Atsushi Obata, Elena Shevliakova, Katharina D. Six, Jerry F. Tjiputra, Evgeny M. Volodin, and Tongwen Wu, (2014) Causes and Implications of Persistent Atmospheric Carbon Dioxide Biases in Earth System Models. J. Geophys. Res. Biogeosci., 119(2):141-162. https://doi.org/10.1002/2013JG002381." ;
                :region = "global_land" ;
                :source = "Annual land carbon storage change = (total anthropogenic CO2 emissions) - (atmospheric carbon storage change) - (ocean carbon storage change)" ;
                :source_data_retrieval_date = "2025-06-12T11:40:21Z" ;
                :source_data_url = "https://www.ilamb.org/ILAMB-Data/DATA/nbp/HOFFMAN/nbp_1850-2010.nc" ;
                :source_id = "Hoffman-1-0" ;
                :source_label = "Hoffman" ;
                :source_type = "stastical-estimate" ;
                :source_version_number = "1.0" ;
                :title = "Land anthropogenic carbon flux estimates" ;
                :tracking_id = "hdl:21.14102/7f4c336a-7205-4b80-b9b8-0edbddd1b8b0" ;
                :variable_id = "nbp" ;
                :variant_info = "CMORized product prepared by ILAMB and CMIP IPO" ;
                :variant_label = "REF" ;
                :version = "v20251117" ;
}
```

Fixed fgco2:
```bash
netcdf obs4MIPs_UCI-ORNL_Hoffman-1-0_yr_fgco2_gm_v20251117 {
dimensions:
        time = UNLIMITED ; // (161 currently)
        bnds = 2 ;
variables:
        float fgco2(time) ;
                fgco2:_FillValue = 1.e+20f ;
                fgco2:long_name = "Surface Downward Mass Flux of Carbon as CO2" ;
                fgco2:units = "Pg yr-1" ;
                fgco2:standard_name = "surface_downward_mass_flux_of_carbon_dioxide_expressed_as_carbon" ;
                fgco2:ancillary_variables = "fgco2_95pci" ;
        double time_bnds(time, bnds) ;
        float fgco2_95pci(time, bnds) ;
                fgco2_95pci:_FillValue = 1.e+20f ;
                fgco2_95pci:units = "Pg yr-1" ;
                fgco2_95pci:long_name = "surface_downward_mass_flux_of_carbon_dioxide_expressed_as_carbon 95_pct_confidence_interval" ;
        double time(time) ;
                time:axis = "T" ;
                time:standard_name = "time" ;
                time:long_name = "time" ;
                time:bounds = "time_bnds" ;
                time:units = "days since 1850-01-01 00:00:00" ;
                time:calendar = "gregorian" ;

// global attributes:
                :activity_id = "obs4MIPs" ;
                :aux_variable_id = "fgco2_95pci" ;
                :comment = "Not yet obs4MIPs compliant: \'version\' attribute is temporary; source_id not in obs4MIPs yet" ;
                :contact = "Forrest Hoffman (forrest@climatemodeling.org)" ;
                :Conventions = "CF-1.12 ODS-2.5" ;
                :creation_date = "2025-11-17T19:59:42Z" ;
                :dataset_contributor = "Morgan Steckler" ;
                :data_specs_version = "2.5" ;
                :doi = "N/A" ;
                :frequency = "yr" ;
                :grid = "global mean data" ;
                :grid_label = "gm" ;
                :has_auxdata = "True" ;
                :history = "\n2025-06-12T11:40:21Z: downloaded https://www.ilamb.org/ILAMB-Data/DATA/nbp/HOFFMAN/nbp_1850-2010.nc;\n2025-11-17T19:59:42Z: converted to obs4MIPs format" ;
                :institution = "University of California at Irvine, Irvine, CA, USA; Oak Ridge National Laboratory, Oak Ridge, TN, USA" ;
                :institution_id = "UCI-ORNL" ;
                :license = "Data in this file produced by ILAMB is licensed under a Creative Commons Attribution- 4.0 International (CC BY 4.0) License (https://creativecommons.org/licenses/)." ;
                :nominal_resolution = "site" ;
                :processing_code_location = "https://github.com/rubisco-sfa/ilamb3-data/blob/main/data/Hoffman/convert.py" ;
                :product = "derived" ;
                :realm = "ocean" ;
                :references = "Hoffman, Forrest M., James T. Randerson, Vivek K. Arora, Qing Bao, Patricia Cadule, Duoying Ji, Chris D. Jones, Michio Kawamiya, Samar Khatiwala, Keith Lindsay, Atsushi Obata, Elena Shevliakova, Katharina D. Six, Jerry F. Tjiputra, Evgeny M. Volodin, and Tongwen Wu, (2014) Causes and Implications of Persistent Atmospheric Carbon Dioxide Biases in Earth System Models. J. Geophys. Res. Biogeosci., 119(2):141-162. https://doi.org/10.1002/2013JG002381." ;
                :region = "global_ocean" ;
                :source = "Annual land carbon storage change = (total anthropogenic CO2 emissions) - (atmospheric carbon storage change) - (ocean carbon storage change)" ;
                :source_data_retrieval_date = "2025-06-12T11:40:21Z" ;
                :source_data_url = "https://www.ilamb.org/ILAMB-Data/DATA/nbp/HOFFMAN/nbp_1850-2010.nc" ;
                :source_id = "Hoffman-1-0" ;
                :source_label = "Hoffman" ;
                :source_type = "stastical-estimate" ;
                :source_version_number = "1.0" ;
                :title = "Ocean anthropogenic carbon flux estimates" ;
                :tracking_id = "hdl:21.14102/7f4c336a-7205-4b80-b9b8-0edbddd1b8b0" ;
                :variable_id = "fgco2" ;
                :variant_info = "CMORized product prepared by ILAMB and CMIP IPO" ;
                :variant_label = "REF" ;
                :version = "v20251117" ;
}
```
